### PR TITLE
Remove Link wrapper around EventCard

### DIFF
--- a/volunteerfinderfront/src/pages/Landing.tsx
+++ b/volunteerfinderfront/src/pages/Landing.tsx
@@ -34,9 +34,7 @@ const Landing = () => {
       />
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {events.map((event: Event) => (
-          <Link to={`/events/${event.id}`} key={event.id}>
-            <EventCard event={event} />
-          </Link>
+          <EventCard event={event} key={event.id} />
         ))}
         <Link
           to="/create-event"


### PR DESCRIPTION
## Summary
- remove redundant Link wrapper around `EventCard` in `Landing`

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4f7127ac8325b9027028c797abef