### PR TITLE
Fix search input accessibility

### DIFF
--- a/volunteerfinderfront/src/components/common/NavBar.tsx
+++ b/volunteerfinderfront/src/components/common/NavBar.tsx
@@ -17,6 +17,7 @@ const NavBar = () => {
       <input
         type="text"
         placeholder="Search events"
+        aria-label="Search events"
         className="border p-1 rounded md:w-1/3"
       />
       <div className="relative">


### PR DESCRIPTION
## Summary
- add `aria-label` for the search input in NavBar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4f7688848325b033321ee5e03fd3