### PR TITLE
Implement basic login routes

### DIFF
--- a/CONNECTION_SETUP.md
+++ b/CONNECTION_SETUP.md
@@ -49,6 +49,10 @@ This guide explains how to connect the frontend and backend of the KIU Volunteer
 - `GET /api/users/load?entity_id={id}` - Get specific user
 - `GET /api/users/random` - Get random user
 
+#### Auth
+- `POST /api/auth/login` - Log in a user
+- `POST /api/auth/register` - Register a new user
+
 ### Data Structure Changes
 
 The frontend has been updated to work with the backend's data structure:
@@ -125,7 +129,6 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 ## Next Steps
 
-- Implement proper authentication system
 - Add error handling and loading states
 - Implement real-time updates using WebSockets
-- Add data validation and sanitization 
+- Add data validation and sanitization

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify'
 import applicationRoutes from './routes/applicationRoutes'
 import userRoutes from './routes/userRoutes'
 import eventRoutes from './routes/eventRoutes'
+import authRoutes from './routes/authRoutes'
 import { db } from './plugins/firebase'
 
 const app = Fastify({
@@ -21,6 +22,7 @@ app.decorate('db', db)
 app.register(userRoutes, { prefix: '/api/users' })
 app.register(applicationRoutes, { prefix: '/api/applications' })
 app.register(eventRoutes, { prefix: '/api/events' })
+app.register(authRoutes, { prefix: '/api/auth' })
 
 const start = async () => {
   try {

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,0 +1,72 @@
+import { FastifyPluginAsync } from 'fastify'
+import { v4 as uuidv4 } from 'uuid'
+
+const authRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/login', async (req, reply) => {
+    const { email, password } = req.body as { email: string; password: string }
+
+    if (!email || !password) {
+      return reply.code(400).send({ message: 'Missing credentials' })
+    }
+
+    const snap = await app.db
+      .collection('users')
+      .where('email', '==', email)
+      .where('password', '==', password)
+      .limit(1)
+      .get()
+
+    if (snap.empty) {
+      return reply.code(401).send({ message: 'Invalid email or password' })
+    }
+
+    const user = snap.docs[0].data()
+
+    return reply.send({ token: uuidv4(), user })
+  })
+
+  app.post('/register', async (req, reply) => {
+    const { name, surname, email, dob, sex, password } = req.body as {
+      name: string
+      surname: string
+      email: string
+      dob: string
+      sex: string
+      password: string
+    }
+
+    if (!name || !surname || !email || !dob || !sex || !password) {
+      return reply.code(400).send({ message: 'Missing fields' })
+    }
+
+    const existing = await app.db
+      .collection('users')
+      .where('email', '==', email)
+      .limit(1)
+      .get()
+
+    if (!existing.empty) {
+      return reply.code(400).send({ message: 'Email already in use' })
+    }
+
+    const user_id = uuidv4()
+    const user = {
+      user_id,
+      first_name: name,
+      last_name: surname,
+      age: 0,
+      sex,
+      email,
+      username: email,
+      password,
+      applications: [],
+      events: [],
+    }
+
+    await app.db.collection('users').doc(user_id).set(user)
+
+    return reply.code(201).send({ token: uuidv4(), user })
+  })
+}
+
+export default authRoutes

--- a/volunteerfinderfront/src/lib/useAuth.tsx
+++ b/volunteerfinderfront/src/lib/useAuth.tsx
@@ -37,7 +37,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   const login: AuthContextValue['login'] = async (data) => {
-    const res = await fetch('/auth/login', {
+    const res = await fetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -51,7 +51,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }
 
   const register: AuthContextValue['register'] = async (data) => {
-    const res = await fetch('/auth/register', {
+    const res = await fetch('/api/auth/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),


### PR DESCRIPTION
## Summary
- add new auth routes to support login and registration
- register auth routes in the backend
- update frontend login API paths
- document new endpoints in CONNECTION_SETUP.md

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing eslint packages)*
- `npm run build` in backend *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d923fdd08832583b3fb2789cb9185