### PR TITLE
Remove token usage in frontend auth

### DIFF
--- a/volunteerfinderfront/src/lib/useAuth.tsx
+++ b/volunteerfinderfront/src/lib/useAuth.tsx
@@ -8,7 +8,6 @@ interface User {
 
 interface AuthContextValue {
   user: User | null
-  token: string | null
   login: (data: { user_identifier: string; password: string }) => Promise<void>
   register: (data: {
     name: string
@@ -25,13 +24,10 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined)
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null)
-  const [token, setToken] = useState<string | null>(null)
 
   useEffect(() => {
-    const storedToken = localStorage.getItem('token')
     const storedUser = localStorage.getItem('user')
-    if (storedToken && storedUser) {
-      setToken(storedToken)
+    if (storedUser) {
       setUser(JSON.parse(storedUser))
     }
   }, [])
@@ -56,21 +52,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     })
     if (!res.ok) throw new Error('Registration failed')
     const result = await res.json()
-    setToken(result.token)
     setUser(result.user)
-    localStorage.setItem('token', result.token)
     localStorage.setItem('user', JSON.stringify(result.user))
   }
 
   const logout = () => {
-    setToken(null)
     setUser(null)
-    localStorage.removeItem('token')
     localStorage.removeItem('user')
   }
 
   return (
-    <AuthContext.Provider value={{ user, token, login, register, logout }}>
+    <AuthContext.Provider value={{ user, login, register, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/volunteerfinderfront/src/mocks/handlers.ts
+++ b/volunteerfinderfront/src/mocks/handlers.ts
@@ -47,9 +47,9 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(applications))
   }),
   rest.post('/auth/register', (req, res, ctx) =>
-    res(ctx.status(200), ctx.json({ token: 'dummy', user: { id: 1, name: 'Alice' } })),
+    res(ctx.status(200), ctx.json({ user: { id: 1, name: 'Alice' } })),
   ),
   rest.post('/auth/login', (req, res, ctx) =>
-    res(ctx.status(200), ctx.json({ token: 'dummy', user: { id: 1, name: 'Alice' } })),
+    res(ctx.status(200), ctx.json({ user: { id: 1, name: 'Alice' } })),
   ),
 ]


### PR DESCRIPTION
## Summary
- update auth context to stop storing token
- adjust mocked auth responses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbbb2bd708325ae8f15d0e02ff65c